### PR TITLE
Evaluation website

### DIFF
--- a/Product/dashboard/src/api.js
+++ b/Product/dashboard/src/api.js
@@ -109,7 +109,7 @@ export function connectPipeline(payload, onMessage, onClose) {
 
 // ── Evaluation ──────────────────────────────────────
 
-export async function generateQuestions(provider, model, docId, numQuestions, chunkStrategy = "semantic") {
+export async function generateQuestions(provider, model, docId, numQuestions, chunkStrategy = "recursive") {
   const form = new FormData();
   form.append("llm_provider", provider || "openai");
   form.append("llm_model", model || "gpt-4o");

--- a/Product/dashboard/src/api.js
+++ b/Product/dashboard/src/api.js
@@ -109,7 +109,23 @@ export function connectPipeline(payload, onMessage, onClose) {
 
 // ── Evaluation ──────────────────────────────────────
 
-export async function startEvaluation(searchTypes, questionSource, file, provider, model, docId) {
+export async function generateQuestions(provider, model, docId, numQuestions) {
+  const form = new FormData();
+  form.append("llm_provider", provider || "openai");
+  form.append("llm_model", model || "gpt-4o");
+  form.append("doc_id", docId);
+  form.append("num_questions", numQuestions);
+
+  const res = await fetch(`${EVALUATOR_BASE}/evaluate/generate-questions`, {
+    method: "POST",
+    headers: headers(),
+    body: form,
+  });
+  if (!res.ok) throw new Error((await res.json()).detail || res.statusText);
+  return res.json();
+}
+
+export async function startEvaluation(searchTypes, questionSource, file, provider, model, docId, qaPairs) {
   const form = new FormData();
   form.append("search_types", searchTypes.join(","));
   form.append("question_source", questionSource);
@@ -117,6 +133,7 @@ export async function startEvaluation(searchTypes, questionSource, file, provide
   form.append("llm_model", model || "gpt-4o");
   if (file) form.append("file", file);
   if (docId) form.append("doc_id", docId);
+  if (qaPairs) form.append("qa_pairs", JSON.stringify(qaPairs));
 
   const res = await fetch(`${EVALUATOR_BASE}/evaluate/start`, {
     method: "POST",

--- a/Product/dashboard/src/api.js
+++ b/Product/dashboard/src/api.js
@@ -109,13 +109,12 @@ export function connectPipeline(payload, onMessage, onClose) {
 
 // ── Evaluation ──────────────────────────────────────
 
-export async function generateQuestions(provider, model, docId, numQuestions, chunkStrategy = "recursive") {
+export async function generateQuestions(provider, model, docId, numQuestions) {
   const form = new FormData();
   form.append("llm_provider", provider || "openai");
   form.append("llm_model", model || "gpt-4o");
   form.append("doc_id", docId);
   form.append("num_questions", numQuestions);
-  form.append("chunk_strategy", chunkStrategy);
 
   const res = await fetch(`${EVALUATOR_BASE}/evaluate/generate-questions`, {
     method: "POST",

--- a/Product/dashboard/src/api.js
+++ b/Product/dashboard/src/api.js
@@ -109,12 +109,13 @@ export function connectPipeline(payload, onMessage, onClose) {
 
 // ── Evaluation ──────────────────────────────────────
 
-export async function generateQuestions(provider, model, docId, numQuestions) {
+export async function generateQuestions(provider, model, docId, numQuestions, chunkStrategy = "semantic") {
   const form = new FormData();
   form.append("llm_provider", provider || "openai");
   form.append("llm_model", model || "gpt-4o");
   form.append("doc_id", docId);
   form.append("num_questions", numQuestions);
+  form.append("chunk_strategy", chunkStrategy);
 
   const res = await fetch(`${EVALUATOR_BASE}/evaluate/generate-questions`, {
     method: "POST",

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -168,6 +168,13 @@ export default function Evaluation() {
     }
   }, [docId, allPastJobs]);
 
+  // Reset loaded questions and approval state if they switch datasets/docs
+  useEffect(() => {
+    setGeneratedQaPairs(null);
+    setIsApproved(false);
+    setReviewExpanded(true);
+  }, [docId, pastJobId, questionSrc]);
+
   function toggle(t) {
     setSelected((prev) =>
       prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -376,7 +376,10 @@ export default function Evaluation() {
               <div style={{ marginTop: 20 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
                   <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
-                  <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs(null)} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs([...generatedQaPairs, { question: "", ground_truth_answer: "" }])} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>➕ Add Question</button>
+                    <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs(null)} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
+                  </div>
                 </div>
                 
                 <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12 }}>

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -402,34 +402,42 @@ export default function Evaluation() {
                   {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
                 </div>
               </div>
-            ) : (
-              <button 
-                className="btn btn-secondary" 
-                onClick={handleGenerateQuestions} 
-                disabled={generating || !docId}
-                style={{ marginTop: 16 }}
-              >
-                {generating ? "Generating..." : "⚙️ Auto-Generate Questions"}
-              </button>
-            )}
+            ) : null}
           </div>
         )}
 
         <div className="flex gap-8 items-center" style={{ marginTop: 20 }}>
-          <button
-            className="btn btn-primary"
-            disabled={loading || !selected.length || (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0))}
-            onClick={start}
-          >
-            {loading ? (
-              <>
-                <span style={{ display: "inline-block", animation: "spin 1s linear infinite" }}>⚙</span>
-                {status ? `${status}…` : "Starting…"}
-              </>
-            ) : (
-              "▶ Start Evaluation"
-            )}
-          </button>
+          {questionSrc === "auto" && !generatedQaPairs ? (
+            <button
+              className="btn btn-primary"
+              disabled={generating || !selected.length || !docId}
+              onClick={handleGenerateQuestions}
+            >
+              {generating ? (
+                <>
+                  <span style={{ display: "inline-block", animation: "spin 1s linear infinite", marginRight: 8 }}>⚙</span>
+                  Generating Questions…
+                </>
+              ) : (
+                "⚙️ Auto-Generate Questions"
+              )}
+            </button>
+          ) : (
+            <button
+              className="btn btn-primary"
+              disabled={loading || !selected.length || (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0))}
+              onClick={start}
+            >
+              {loading ? (
+                <>
+                  <span style={{ display: "inline-block", animation: "spin 1s linear infinite", marginRight: 8 }}>⚙</span>
+                  {status ? `${status}…` : "Starting…"}
+                </>
+              ) : (
+                "▶ Start Evaluation"
+              )}
+            </button>
+          )}
         </div>
       </div>
 

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { startEvaluation, getEvalStatus, getEvalResults, getDocuments } from "../api";
+import { startEvaluation, getEvalStatus, getEvalResults, getDocuments, generateQuestions } from "../api";
 import { exportEvalResults } from "../utils/exportCsv";
 import {
   Chart as ChartJS,
@@ -129,6 +129,11 @@ export default function Evaluation() {
   const [results, setResults] = useState(null);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  
+  const [numQuestions, setNumQuestions] = useState(10);
+  const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
+  const [generating, setGenerating] = useState(false);
+
   const pollRef = useRef(null);
   const fileRef = useRef();
   const logEndRef = useRef(null);
@@ -154,12 +159,19 @@ export default function Evaluation() {
 
   async function start() {
     if (!selected.length) return;
+    if (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0)) {
+      setError("Please generate and review questions first.");
+      return;
+    }
     setError("");
     setResults(null);
     setLogs([]);
     setLoading(true);
     try {
-      const res = await startEvaluation(selected, questionSrc, file, provider, model, docId);
+      const qaPairsToPass = questionSrc === "auto" ? generatedQaPairs : null;
+      const actualSource = questionSrc === "auto" ? "manual" : questionSrc;
+      
+      const res = await startEvaluation(selected, actualSource, file, provider, model, docId, qaPairsToPass);
       setJobId(res.job_id);
       setStatus("pending");
       setProgressMsg("");
@@ -168,6 +180,21 @@ export default function Evaluation() {
     } catch (e) {
       setError(e.message);
       setLoading(false);
+    }
+  }
+
+  async function handleGenerateQuestions() {
+    if (!docId) return;
+    setError("");
+    setGenerating(true);
+    setGeneratedQaPairs(null);
+    try {
+      const res = await generateQuestions(provider, model, docId, numQuestions);
+      setGeneratedQaPairs(res.questions || []);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setGenerating(false);
     }
   }
 
@@ -326,20 +353,72 @@ export default function Evaluation() {
         ) : (
           <div className="card-body">
             <p style={{ marginBottom: "12px" }}>Auto-generate evaluation questions from your existing documents.</p>
-            <div className="form-group row">
-              <label>Target Document</label>
-              <select value={docId} onChange={e => setDocId(e.target.value)}>
-                {docs.length === 0 ? <option value="">No documents found</option> : null}
-                {docs.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
-              </select>
+            <div className="form-row">
+              <div className="form-group" style={{ marginBottom: 0, flex: 1 }}>
+                <label>Target Document</label>
+                <select value={docId} onChange={e => setDocId(e.target.value)}>
+                  {docs.length === 0 ? <option value="">No documents found</option> : null}
+                  {docs.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+                </select>
+              </div>
+              <div className="form-group" style={{ marginBottom: 0, width: "120px" }}>
+                <label># Questions</label>
+                <input 
+                  type="number" 
+                  min={1} max={20} 
+                  value={numQuestions} 
+                  onChange={e => setNumQuestions(Number(e.target.value))} 
+                />
+              </div>
             </div>
+            
+            {generatedQaPairs ? (
+              <div style={{ marginTop: 20 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+                  <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
+                  <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs(null)} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
+                </div>
+                
+                <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12 }}>
+                  {generatedQaPairs.map((pair, idx) => (
+                    <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
+                         <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
+                         <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
+                      </div>
+                      <input 
+                        type="text" 
+                        value={pair.question} 
+                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
+                        style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                      />
+                      <textarea 
+                        value={pair.ground_truth_answer} 
+                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
+                        style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                      />
+                    </div>
+                  ))}
+                  {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
+                </div>
+              </div>
+            ) : (
+              <button 
+                className="btn btn-secondary" 
+                onClick={handleGenerateQuestions} 
+                disabled={generating || !docId}
+                style={{ marginTop: 16 }}
+              >
+                {generating ? "Generating..." : "⚙️ Auto-Generate Questions"}
+              </button>
+            )}
           </div>
         )}
 
-        <div className="flex gap-8 items-center">
+        <div className="flex gap-8 items-center" style={{ marginTop: 20 }}>
           <button
             className="btn btn-primary"
-            disabled={loading || !selected.length}
+            disabled={loading || !selected.length || (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0))}
             onClick={start}
           >
             {loading ? (

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -489,7 +489,7 @@ export default function Evaluation() {
               >
                 <div>
                   <span style={{ marginRight: 8 }}>✅</span>
-                  <strong>Approved Dataset</strong> — Document: {docs.find(d => d.id === docId)?.name || docId}
+                  <strong>Approved Dataset {questionSrc === "auto" ? "- New" : `- Reused (${allPastJobs.find(j => j.id === pastJobId)?.created_at ? new Date(allPastJobs.find(j => j.id === pastJobId).created_at).toLocaleString() : ''})`}</strong> — Document: {docs.find(d => d.id === docId)?.name || docId}
                 </div>
                 <span style={{ color: "var(--text-dim)", fontSize: 13 }}>{generatedQaPairs.length} questions (Click to edit)</span>
               </div>

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -131,7 +131,6 @@ export default function Evaluation() {
   const [loading, setLoading] = useState(false);
 
   const [numQuestions, setNumQuestions] = useState(10);
-  const [chunkStrategy, setChunkStrategy] = useState("recursive");
   const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
   const [generating, setGenerating] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
@@ -218,7 +217,7 @@ export default function Evaluation() {
     setIsApproved(false);
     setReviewExpanded(true);
     try {
-      const res = await generateQuestions(provider, model, docId, numQuestions, chunkStrategy);
+      const res = await generateQuestions(provider, model, docId, numQuestions);
       setGeneratedQaPairs(res.questions || []);
     } catch (e) {
       setError(e.message);
@@ -463,15 +462,6 @@ export default function Evaluation() {
                   value={numQuestions}
                   onChange={e => setNumQuestions(Number(e.target.value))}
                 />
-              </div>
-              <div className="form-group" style={{ marginBottom: 0, width: "180px" }}>
-                <label>Chunking Strategy</label>
-                <select value={chunkStrategy} onChange={e => setChunkStrategy(e.target.value)}>
-                  <option value="recursive">Recursive</option>
-                  <option value="semantic">Semantic</option>
-                  <option value="summarization">Summarization</option>
-                  <option value="character">Character</option>
-                </select>
               </div>
             </div>
 

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -131,6 +131,7 @@ export default function Evaluation() {
   const [loading, setLoading] = useState(false);
   
   const [numQuestions, setNumQuestions] = useState(10);
+  const [chunkStrategy, setChunkStrategy] = useState("semantic");
   const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
   const [generating, setGenerating] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
@@ -217,7 +218,7 @@ export default function Evaluation() {
     setIsApproved(false);
     setReviewExpanded(true);
     try {
-      const res = await generateQuestions(provider, model, docId, numQuestions);
+      const res = await generateQuestions(provider, model, docId, numQuestions, chunkStrategy);
       setGeneratedQaPairs(res.questions || []);
     } catch (e) {
       setError(e.message);
@@ -462,6 +463,14 @@ export default function Evaluation() {
                   value={numQuestions} 
                   onChange={e => setNumQuestions(Number(e.target.value))} 
                 />
+              </div>
+              <div className="form-group" style={{ marginBottom: 0, width: "180px" }}>
+                <label>Chunking Strategy</label>
+                <select value={chunkStrategy} onChange={e => setChunkStrategy(e.target.value)}>
+                  <option value="semantic">Semantic Overlap</option>
+                  <option value="basic">Basic (Legacy)</option>
+                  <option value="summarization" disabled>Summarization (Soon)</option>
+                </select>
               </div>
             </div>
             

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -47,7 +47,7 @@ const CHART_BORDERS = [
 function classifyLog(text) {
   const t = (text || "").toLowerCase();
   if (t.includes("error") || t.includes("failed") || t.includes("exception")) return "log-error";
-  if (t.includes("warn"))                  return "log-warn";
+  if (t.includes("warn")) return "log-warn";
   if (t.includes("evaluating") || t.includes("generating") || t.includes("parsing") || t.includes("starting")) return "log-step";
   if (t.includes("complete") || t.includes("done") || t.includes("success") || t.includes("finished")) return "log-ok";
   return "";
@@ -55,9 +55,9 @@ function classifyLog(text) {
 
 function logPrefix(cls) {
   if (cls === "log-error") return "✖";
-  if (cls === "log-warn")  return "⚠";
-  if (cls === "log-step")  return "◆";
-  if (cls === "log-ok")    return "✔";
+  if (cls === "log-warn") return "⚠";
+  if (cls === "log-step") return "◆";
+  if (cls === "log-ok") return "✔";
   return "›";
 }
 
@@ -129,14 +129,14 @@ export default function Evaluation() {
   const [results, setResults] = useState(null);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  
+
   const [numQuestions, setNumQuestions] = useState(10);
   const [chunkStrategy, setChunkStrategy] = useState("recursive");
   const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
   const [generating, setGenerating] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
   const [reviewExpanded, setReviewExpanded] = useState(true);
-  
+
   const [allPastJobs, setAllPastJobs] = useState([]);
   const [pastJobId, setPastJobId] = useState("");
   const [loadingPast, setLoadingPast] = useState(false);
@@ -197,7 +197,7 @@ export default function Evaluation() {
     try {
       const qaPairsToPass = (questionSrc === "auto" || questionSrc === "past") ? generatedQaPairs : null;
       const actualSource = (questionSrc === "auto" || questionSrc === "past") ? "manual" : questionSrc;
-      
+
       const res = await startEvaluation(selected, actualSource, file, provider, model, docId, qaPairsToPass);
       setJobId(res.job_id);
       setStatus("pending");
@@ -257,7 +257,7 @@ export default function Evaluation() {
         const s = await getEvalStatus(id);
         setStatus(s.status);
         setProgressMsg(s.progress || "");
-        
+
         if (s.progress) {
           setLogs(prev => {
             if (prev.length > 0 && prev[prev.length - 1].text === s.progress) return prev;
@@ -268,7 +268,7 @@ export default function Evaluation() {
         if (s.status === "completed" || s.status === "failed") {
           clearInterval(pollRef.current);
           setLoading(false);
-          
+
           if (s.status === "completed") {
             const r = await getEvalResults(id);
             setResults(r.results);
@@ -432,11 +432,11 @@ export default function Evaluation() {
                 </select>
               </div>
             </div>
-            
+
             {!generatedQaPairs && (
-              <button 
-                className="btn btn-secondary" 
-                onClick={handleLoadPastDataset} 
+              <button
+                className="btn btn-secondary"
+                onClick={handleLoadPastDataset}
                 disabled={loadingPast || !pastJobId}
                 style={{ marginTop: 16 }}
               >
@@ -457,11 +457,11 @@ export default function Evaluation() {
               </div>
               <div className="form-group" style={{ marginBottom: 0, width: "120px" }}>
                 <label># Questions</label>
-                <input 
-                  type="number" 
-                  min={1} max={20} 
-                  value={numQuestions} 
-                  onChange={e => setNumQuestions(Number(e.target.value))} 
+                <input
+                  type="number"
+                  min={1} max={20}
+                  value={numQuestions}
+                  onChange={e => setNumQuestions(Number(e.target.value))}
                 />
               </div>
               <div className="form-group" style={{ marginBottom: 0, width: "180px" }}>
@@ -474,20 +474,20 @@ export default function Evaluation() {
                 </select>
               </div>
             </div>
-            
+
           </div>
         )}
 
         {(questionSrc === "auto" || questionSrc === "past") && generatedQaPairs ? (
           <div style={{ marginTop: 20 }}>
             {!reviewExpanded ? (
-              <div 
+              <div
                 onClick={() => { setReviewExpanded(true); setIsApproved(false); }}
-                style={{ 
-                  padding: "12px 16px", 
-                  border: "1px solid var(--border)", 
-                  borderRadius: 6, 
-                  background: "var(--bg-card-hover)", 
+                style={{
+                  padding: "12px 16px",
+                  border: "1px solid var(--border)",
+                  borderRadius: 6,
+                  background: "var(--bg-card-hover)",
                   cursor: "pointer",
                   display: "flex",
                   justifyContent: "space-between",
@@ -509,25 +509,25 @@ export default function Evaluation() {
                     {questionSrc === "auto" && <button className="btn btn-secondary" onClick={() => { setGeneratedQaPairs(null); setIsApproved(false); }} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>}
                   </div>
                 </div>
-                
+
                 <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 12 }}>
                   {generatedQaPairs.map((pair, idx) => (
                     <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
-                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
-                         <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
-                         <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
+                        <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
+                        <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer" }} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
                       </div>
-                      <input 
-                        type="text" 
-                        value={pair.question} 
+                      <input
+                        type="text"
+                        value={pair.question}
                         placeholder="Question"
-                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
+                        onChange={e => setGeneratedQaPairs(prev => { const n = [...prev]; n[idx].question = e.target.value; return n; })}
                         style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
                       />
-                      <textarea 
-                        value={pair.ground_truth_answer} 
+                      <textarea
+                        value={pair.ground_truth_answer}
                         placeholder="Ground truth answer"
-                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
+                        onChange={e => setGeneratedQaPairs(prev => { const n = [...prev]; n[idx].ground_truth_answer = e.target.value; return n; })}
                         style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
                       />
                     </div>
@@ -535,8 +535,8 @@ export default function Evaluation() {
                   {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
                 </div>
 
-                <button 
-                  className="btn btn-primary" 
+                <button
+                  className="btn btn-primary"
                   onClick={() => { setIsApproved(true); setReviewExpanded(false); }}
                   disabled={generatedQaPairs.length === 0}
                   style={{ width: "100%", justifyContent: "center" }}
@@ -566,7 +566,7 @@ export default function Evaluation() {
             </button>
           ) : (
             <button
-               className="btn btn-primary"
+              className="btn btn-primary"
               disabled={loading || !selected.length || ((questionSrc === "auto" || questionSrc === "past") && !isApproved)}
               onClick={start}
             >
@@ -592,8 +592,8 @@ export default function Evaluation() {
               <h3>Results</h3>
               <div className="card-subtitle">Comparing {results.length} search strategies</div>
             </div>
-            <button 
-              className="btn btn-secondary" 
+            <button
+              className="btn btn-secondary"
               onClick={() => exportEvalResults(results)}
               style={{ fontSize: 13, height: 32 }}
             >

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -133,6 +133,8 @@ export default function Evaluation() {
   const [numQuestions, setNumQuestions] = useState(10);
   const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
   const [generating, setGenerating] = useState(false);
+  const [isApproved, setIsApproved] = useState(false);
+  const [reviewExpanded, setReviewExpanded] = useState(true);
 
   const pollRef = useRef(null);
   const fileRef = useRef();
@@ -159,8 +161,8 @@ export default function Evaluation() {
 
   async function start() {
     if (!selected.length) return;
-    if (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0)) {
-      setError("Please generate and review questions first.");
+    if (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0 || !isApproved)) {
+      setError("Please generate, review, and approve questions first.");
       return;
     }
     setError("");
@@ -188,6 +190,8 @@ export default function Evaluation() {
     setError("");
     setGenerating(true);
     setGeneratedQaPairs(null);
+    setIsApproved(false);
+    setReviewExpanded(true);
     try {
       const res = await generateQuestions(provider, model, docId, numQuestions);
       setGeneratedQaPairs(res.questions || []);
@@ -374,36 +378,71 @@ export default function Evaluation() {
             
             {generatedQaPairs ? (
               <div style={{ marginTop: 20 }}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
-                  <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
-                  <div style={{ display: "flex", gap: 8 }}>
-                    <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs([...generatedQaPairs, { question: "", ground_truth_answer: "" }])} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>➕ Add Question</button>
-                    <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs(null)} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
-                  </div>
-                </div>
-                
-                <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12 }}>
-                  {generatedQaPairs.map((pair, idx) => (
-                    <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
-                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
-                         <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
-                         <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
-                      </div>
-                      <input 
-                        type="text" 
-                        value={pair.question} 
-                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
-                        style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
-                      />
-                      <textarea 
-                        value={pair.ground_truth_answer} 
-                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
-                        style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
-                      />
+                {!reviewExpanded ? (
+                  <div 
+                    onClick={() => { setReviewExpanded(true); setIsApproved(false); }}
+                    style={{ 
+                      padding: "12px 16px", 
+                      border: "1px solid var(--border)", 
+                      borderRadius: 6, 
+                      background: "var(--bg-card-hover)", 
+                      cursor: "pointer",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center"
+                    }}
+                  >
+                    <div>
+                      <span style={{ marginRight: 8 }}>✅</span>
+                      <strong>Approved Dataset</strong> — Document: {docs.find(d => d.id === docId)?.name || docId}
                     </div>
-                  ))}
-                  {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
-                </div>
+                    <span style={{ color: "var(--text-dim)", fontSize: 13 }}>{generatedQaPairs.length} questions (Click to edit)</span>
+                  </div>
+                ) : (
+                  <>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+                      <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
+                      <div style={{ display: "flex", gap: 8 }}>
+                        <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs([...generatedQaPairs, { question: "", ground_truth_answer: "" }])} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>➕ Add Question</button>
+                        <button className="btn btn-secondary" onClick={() => { setGeneratedQaPairs(null); setIsApproved(false); }} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
+                      </div>
+                    </div>
+                    
+                    <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 12 }}>
+                      {generatedQaPairs.map((pair, idx) => (
+                        <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
+                          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
+                             <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
+                             <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
+                          </div>
+                          <input 
+                            type="text" 
+                            value={pair.question} 
+                            placeholder="Question"
+                            onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
+                            style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                          />
+                          <textarea 
+                            value={pair.ground_truth_answer} 
+                            placeholder="Ground truth answer"
+                            onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
+                            style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                          />
+                        </div>
+                      ))}
+                      {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
+                    </div>
+
+                    <button 
+                      className="btn btn-primary" 
+                      onClick={() => { setIsApproved(true); setReviewExpanded(false); }}
+                      disabled={generatedQaPairs.length === 0}
+                      style={{ width: "100%", justifyContent: "center" }}
+                    >
+                      ✅ Approve Dataset
+                    </button>
+                  </>
+                )}
               </div>
             ) : null}
           </div>
@@ -428,7 +467,7 @@ export default function Evaluation() {
           ) : (
             <button
               className="btn btn-primary"
-              disabled={loading || !selected.length || (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0))}
+              disabled={loading || !selected.length || (questionSrc === "auto" && !isApproved)}
               onClick={start}
             >
               {loading ? (

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -465,16 +465,6 @@ export default function Evaluation() {
               </div>
             </div>
             
-            {(!generatedQaPairs && questionSrc === "auto") ? (
-              <button 
-                className="btn btn-secondary" 
-                onClick={handleGenerateQuestions} 
-                disabled={generating || !docId}
-                style={{ marginTop: 16 }}
-              >
-                {generating ? "Generating..." : "⚙️ Auto-Generate Questions"}
-              </button>
-            ) : null}
           </div>
         )}
 

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -131,7 +131,7 @@ export default function Evaluation() {
   const [loading, setLoading] = useState(false);
   
   const [numQuestions, setNumQuestions] = useState(10);
-  const [chunkStrategy, setChunkStrategy] = useState("semantic");
+  const [chunkStrategy, setChunkStrategy] = useState("recursive");
   const [generatedQaPairs, setGeneratedQaPairs] = useState(null);
   const [generating, setGenerating] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
@@ -467,9 +467,10 @@ export default function Evaluation() {
               <div className="form-group" style={{ marginBottom: 0, width: "180px" }}>
                 <label>Chunking Strategy</label>
                 <select value={chunkStrategy} onChange={e => setChunkStrategy(e.target.value)}>
-                  <option value="semantic">Semantic Overlap</option>
-                  <option value="basic">Basic (Legacy)</option>
-                  <option value="summarization" disabled>Summarization (Soon)</option>
+                  <option value="recursive">Recursive</option>
+                  <option value="semantic">Semantic</option>
+                  <option value="summarization">Summarization</option>
+                  <option value="character">Character</option>
                 </select>
               </div>
             </div>

--- a/Product/dashboard/src/pages/Evaluation.jsx
+++ b/Product/dashboard/src/pages/Evaluation.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { startEvaluation, getEvalStatus, getEvalResults, getDocuments, generateQuestions } from "../api";
+import { startEvaluation, getEvalStatus, getEvalResults, getDocuments, generateQuestions, getEvaluationJobs, getEvaluationJobDetails } from "../api";
 import { exportEvalResults } from "../utils/exportCsv";
 import {
   Chart as ChartJS,
@@ -135,6 +135,10 @@ export default function Evaluation() {
   const [generating, setGenerating] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
   const [reviewExpanded, setReviewExpanded] = useState(true);
+  
+  const [allPastJobs, setAllPastJobs] = useState([]);
+  const [pastJobId, setPastJobId] = useState("");
+  const [loadingPast, setLoadingPast] = useState(false);
 
   const pollRef = useRef(null);
   const fileRef = useRef();
@@ -149,7 +153,20 @@ export default function Evaluation() {
       setDocs(d);
       if (d.length) setDocId(d[0].id);
     });
+    getEvaluationJobs().then(jobs => {
+      setAllPastJobs(jobs);
+    });
   }, []);
+
+  // Update selected past job when document or jobs change
+  useEffect(() => {
+    const docJobs = allPastJobs.filter(j => j.document_id === docId);
+    if (docJobs.length > 0) {
+      setPastJobId(docJobs[0].id);
+    } else {
+      setPastJobId("");
+    }
+  }, [docId, allPastJobs]);
 
   function toggle(t) {
     setSelected((prev) =>
@@ -161,8 +178,8 @@ export default function Evaluation() {
 
   async function start() {
     if (!selected.length) return;
-    if (questionSrc === "auto" && (!generatedQaPairs || generatedQaPairs.length === 0 || !isApproved)) {
-      setError("Please generate, review, and approve questions first.");
+    if ((questionSrc === "auto" || questionSrc === "past") && (!generatedQaPairs || generatedQaPairs.length === 0 || !isApproved)) {
+      setError("Please generate/load, review, and approve questions first.");
       return;
     }
     setError("");
@@ -170,8 +187,8 @@ export default function Evaluation() {
     setLogs([]);
     setLoading(true);
     try {
-      const qaPairsToPass = questionSrc === "auto" ? generatedQaPairs : null;
-      const actualSource = questionSrc === "auto" ? "manual" : questionSrc;
+      const qaPairsToPass = (questionSrc === "auto" || questionSrc === "past") ? generatedQaPairs : null;
+      const actualSource = (questionSrc === "auto" || questionSrc === "past") ? "manual" : questionSrc;
       
       const res = await startEvaluation(selected, actualSource, file, provider, model, docId, qaPairsToPass);
       setJobId(res.job_id);
@@ -199,6 +216,30 @@ export default function Evaluation() {
       setError(e.message);
     } finally {
       setGenerating(false);
+    }
+  }
+
+  async function handleLoadPastDataset() {
+    if (!pastJobId) return;
+    setError("");
+    setLoadingPast(true);
+    setGeneratedQaPairs(null);
+    setIsApproved(false);
+    setReviewExpanded(true);
+    try {
+      const details = await getEvaluationJobDetails(pastJobId);
+      if (details?.qa_pairs) {
+        setGeneratedQaPairs(details.qa_pairs.map(p => ({
+          question: p.question,
+          ground_truth_answer: p.ground_truth_answer
+        })));
+      } else {
+        setError("No questions found in this past dataset.");
+      }
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoadingPast(false);
     }
   }
 
@@ -328,11 +369,19 @@ export default function Evaluation() {
           </div>
           <div
             className={`radio-opt ${questionSrc === "custom" ? "selected" : ""}`}
-            onClick={() => setQuestionSrc("custom")}
+            onClick={() => { setQuestionSrc("custom"); setGeneratedQaPairs(null); setIsApproved(false); }}
           >
             <input type="radio" readOnly checked={questionSrc === "custom"} />
             <div className="radio-opt-label">📂 Upload CSV</div>
             <div className="radio-opt-desc">question, ground_truth_answer columns</div>
+          </div>
+          <div
+            className={`radio-opt ${questionSrc === "past" ? "selected" : ""}`}
+            onClick={() => { setQuestionSrc("past"); setGeneratedQaPairs(null); setIsApproved(false); }}
+          >
+            <input type="radio" readOnly checked={questionSrc === "past"} />
+            <div className="radio-opt-label">💾 Past Dataset</div>
+            <div className="radio-opt-desc">Reuse questions generated in the past</div>
           </div>
         </div>
 
@@ -353,6 +402,39 @@ export default function Evaluation() {
               accept=".csv"
               onChange={(e) => setFile(e.target.files[0])}
             />
+          </div>
+        ) : questionSrc === "past" ? (
+          <div className="card-body">
+            <p style={{ marginBottom: "12px" }}>Load a previously generated dataset for the selected document.</p>
+            <div className="form-row">
+              <div className="form-group" style={{ marginBottom: 0, flex: 1 }}>
+                <label>Target Document</label>
+                <select value={docId} onChange={e => setDocId(e.target.value)}>
+                  {docs.length === 0 ? <option value="">No documents found</option> : null}
+                  {docs.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+                </select>
+              </div>
+              <div className="form-group" style={{ marginBottom: 0, flex: 2 }}>
+                <label>Select Past Dataset</label>
+                <select value={pastJobId} onChange={e => setPastJobId(e.target.value)}>
+                  {allPastJobs.filter(j => j.document_id === docId).length === 0 ? <option value="">No past datasets found for this document</option> : null}
+                  {allPastJobs.filter(j => j.document_id === docId).map(j => (
+                    <option key={j.id} value={j.id}>{new Date(j.created_at).toLocaleString()} - source: {j.question_source}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            
+            {!generatedQaPairs && (
+              <button 
+                className="btn btn-secondary" 
+                onClick={handleLoadPastDataset} 
+                disabled={loadingPast || !pastJobId}
+                style={{ marginTop: 16 }}
+              >
+                {loadingPast ? "Loading..." : "⬇️ Load Selected Dataset"}
+              </button>
+            )}
           </div>
         ) : (
           <div className="card-body">
@@ -376,77 +458,88 @@ export default function Evaluation() {
               </div>
             </div>
             
-            {generatedQaPairs ? (
-              <div style={{ marginTop: 20 }}>
-                {!reviewExpanded ? (
-                  <div 
-                    onClick={() => { setReviewExpanded(true); setIsApproved(false); }}
-                    style={{ 
-                      padding: "12px 16px", 
-                      border: "1px solid var(--border)", 
-                      borderRadius: 6, 
-                      background: "var(--bg-card-hover)", 
-                      cursor: "pointer",
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center"
-                    }}
-                  >
-                    <div>
-                      <span style={{ marginRight: 8 }}>✅</span>
-                      <strong>Approved Dataset</strong> — Document: {docs.find(d => d.id === docId)?.name || docId}
-                    </div>
-                    <span style={{ color: "var(--text-dim)", fontSize: 13 }}>{generatedQaPairs.length} questions (Click to edit)</span>
-                  </div>
-                ) : (
-                  <>
-                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
-                      <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
-                      <div style={{ display: "flex", gap: 8 }}>
-                        <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs([...generatedQaPairs, { question: "", ground_truth_answer: "" }])} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>➕ Add Question</button>
-                        <button className="btn btn-secondary" onClick={() => { setGeneratedQaPairs(null); setIsApproved(false); }} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>
-                      </div>
-                    </div>
-                    
-                    <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 12 }}>
-                      {generatedQaPairs.map((pair, idx) => (
-                        <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
-                          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
-                             <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
-                             <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
-                          </div>
-                          <input 
-                            type="text" 
-                            value={pair.question} 
-                            placeholder="Question"
-                            onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
-                            style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
-                          />
-                          <textarea 
-                            value={pair.ground_truth_answer} 
-                            placeholder="Ground truth answer"
-                            onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
-                            style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
-                          />
-                        </div>
-                      ))}
-                      {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
-                    </div>
-
-                    <button 
-                      className="btn btn-primary" 
-                      onClick={() => { setIsApproved(true); setReviewExpanded(false); }}
-                      disabled={generatedQaPairs.length === 0}
-                      style={{ width: "100%", justifyContent: "center" }}
-                    >
-                      ✅ Approve Dataset
-                    </button>
-                  </>
-                )}
-              </div>
+            {(!generatedQaPairs && questionSrc === "auto") ? (
+              <button 
+                className="btn btn-secondary" 
+                onClick={handleGenerateQuestions} 
+                disabled={generating || !docId}
+                style={{ marginTop: 16 }}
+              >
+                {generating ? "Generating..." : "⚙️ Auto-Generate Questions"}
+              </button>
             ) : null}
           </div>
         )}
+
+        {(questionSrc === "auto" || questionSrc === "past") && generatedQaPairs ? (
+          <div style={{ marginTop: 20 }}>
+            {!reviewExpanded ? (
+              <div 
+                onClick={() => { setReviewExpanded(true); setIsApproved(false); }}
+                style={{ 
+                  padding: "12px 16px", 
+                  border: "1px solid var(--border)", 
+                  borderRadius: 6, 
+                  background: "var(--bg-card-hover)", 
+                  cursor: "pointer",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center"
+                }}
+              >
+                <div>
+                  <span style={{ marginRight: 8 }}>✅</span>
+                  <strong>Approved Dataset</strong> — Document: {docs.find(d => d.id === docId)?.name || docId}
+                </div>
+                <span style={{ color: "var(--text-dim)", fontSize: 13 }}>{generatedQaPairs.length} questions (Click to edit)</span>
+              </div>
+            ) : (
+              <>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+                  <h4 style={{ margin: 0 }}>Review Questions ({generatedQaPairs.length})</h4>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button className="btn btn-secondary" onClick={() => setGeneratedQaPairs([...generatedQaPairs, { question: "", ground_truth_answer: "" }])} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>➕ Add Question</button>
+                    {questionSrc === "auto" && <button className="btn btn-secondary" onClick={() => { setGeneratedQaPairs(null); setIsApproved(false); }} style={{ padding: "4px 8px", fontSize: 12, height: "auto" }}>Regenerate</button>}
+                  </div>
+                </div>
+                
+                <div style={{ maxHeight: 400, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 12 }}>
+                  {generatedQaPairs.map((pair, idx) => (
+                    <div key={idx} style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4}}>
+                         <strong style={{ fontSize: 13, color: "var(--text-dim)" }}>Q{idx + 1}</strong>
+                         <button style={{ background: "transparent", border: "none", color: "var(--text-dim)", cursor: "pointer"}} onClick={() => setGeneratedQaPairs(prev => prev.filter((_, i) => i !== idx))}>🗑️</button>
+                      </div>
+                      <input 
+                        type="text" 
+                        value={pair.question} 
+                        placeholder="Question"
+                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].question=e.target.value; return n; })}
+                        style={{ width: "100%", marginBottom: 8, padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                      />
+                      <textarea 
+                        value={pair.ground_truth_answer} 
+                        placeholder="Ground truth answer"
+                        onChange={e => setGeneratedQaPairs(prev => { const n=[...prev]; n[idx].ground_truth_answer=e.target.value; return n; })}
+                        style={{ width: "100%", height: 60, resize: "vertical", fontFamily: "inherit", padding: 8, border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-card)", color: "var(--text)" }}
+                      />
+                    </div>
+                  ))}
+                  {generatedQaPairs.length === 0 && <p style={{ color: "var(--text-dim)", textAlign: "center", margin: 0 }}>No questions left.</p>}
+                </div>
+
+                <button 
+                  className="btn btn-primary" 
+                  onClick={() => { setIsApproved(true); setReviewExpanded(false); }}
+                  disabled={generatedQaPairs.length === 0}
+                  style={{ width: "100%", justifyContent: "center" }}
+                >
+                  ✅ Approve Dataset
+                </button>
+              </>
+            )}
+          </div>
+        ) : null}
 
         <div className="flex gap-8 items-center" style={{ marginTop: 20 }}>
           {questionSrc === "auto" && !generatedQaPairs ? (
@@ -466,8 +559,8 @@ export default function Evaluation() {
             </button>
           ) : (
             <button
-              className="btn btn-primary"
-              disabled={loading || !selected.length || (questionSrc === "auto" && !isApproved)}
+               className="btn btn-primary"
+              disabled={loading || !selected.length || ((questionSrc === "auto" || questionSrc === "past") && !isApproved)}
               onClick={start}
             >
               {loading ? (

--- a/Product/dashboard/src/pages/History.jsx
+++ b/Product/dashboard/src/pages/History.jsx
@@ -1,6 +1,65 @@
 import { useState, useEffect } from "react";
-import { getPipelineRuns, getEvaluationJobs, getEvaluationJobDetails } from "../api";
+import { getPipelineRuns, getEvaluationJobs, getEvaluationJobDetails, getDocuments } from "../api";
 import { exportEvalResults, exportEvalDetails } from "../utils/exportCsv";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const CHART_COLORS = [
+  "rgba(139,92,246,0.7)",
+  "rgba(34,211,238,0.7)",
+  "rgba(16,185,129,0.7)",
+  "rgba(245,158,11,0.7)",
+  "rgba(239,68,68,0.7)",
+  "rgba(99,102,241,0.7)",
+];
+
+const CHART_BORDERS = [
+  "rgba(139,92,246,1)",
+  "rgba(34,211,238,1)",
+  "rgba(16,185,129,1)",
+  "rgba(245,158,11,1)",
+  "rgba(239,68,68,1)",
+  "rgba(99,102,241,1)",
+];
+
+function makeChart(title, labels, values) {
+  return {
+    labels,
+    datasets: [
+      {
+        label: title,
+        data: values,
+        backgroundColor: CHART_COLORS.slice(0, labels.length),
+        borderColor: CHART_BORDERS.slice(0, labels.length),
+        borderWidth: 1.5,
+        borderRadius: 6,
+      },
+    ],
+  };
+}
+
+const chartOpts = (title) => ({
+  responsive: true,
+  plugins: {
+    legend: { display: false },
+    title: { display: true, text: title, font: { size: 12, family: "'Inter', sans-serif", weight: "600" }, color: "#64748b", padding: { bottom: 12 } },
+    tooltip: { backgroundColor: "rgba(15,17,32,0.95)", borderColor: "rgba(139,92,246,0.3)", borderWidth: 1, titleColor: "#e2e8f0", bodyColor: "#94a3b8", padding: 10 },
+  },
+  scales: {
+    y: { beginAtZero: true, grid: { color: "rgba(255,255,255,0.05)" }, ticks: { color: "#64748b", font: { size: 11 } } },
+    x: { grid: { display: false }, ticks: { color: "#94a3b8", font: { size: 11 } } },
+  },
+});
 
 function Badge({ status }) {
   const s = (status || "").toLowerCase();
@@ -32,6 +91,7 @@ export default function History() {
   const [selectedRun, setSelectedRun] = useState(null);
   const [selectedJob, setSelectedJob] = useState(null);
   const [jobDetails, setJobDetails] = useState(null);
+  const [docs, setDocs] = useState([]);
 
   async function handleJobClick(job) {
     setSelectedJob(job);
@@ -43,6 +103,7 @@ export default function History() {
   useEffect(() => {
     getPipelineRuns().then(setRuns);
     getEvaluationJobs().then(setJobs);
+    getDocuments().then(setDocs);
   }, []);
 
   return (
@@ -146,15 +207,19 @@ export default function History() {
                 <thead>
                   <tr>
                     <th>Job ID</th>
+                    <th>Document</th>
                     <th>Search Types</th>
                     <th>Status</th>
-                    <th>Created</th>
+                    <th>Created At</th>
                   </tr>
                 </thead>
                 <tbody>
                   {jobs.map((j) => (
                     <tr key={j.id} className="clickable-row" onClick={() => handleJobClick(j)}>
                       <td className="td-mono">{j.id.slice(0, 8)}…</td>
+                      <td style={{ fontWeight: 500 }}>
+                        📄 {docs.find(d => d.id === j.document_id)?.name || (j.document_id ? j.document_id.slice(0, 8) + '…' : 'Unknown')}
+                      </td>
                       <td>
                         <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
                           {(Array.isArray(j.search_types)
@@ -168,7 +233,7 @@ export default function History() {
                         </div>
                       </td>
                       <td><Badge status={j.status} /></td>
-                      <td><RelTime iso={j.created_at} /></td>
+                      <td>{new Date(j.created_at).toLocaleString()}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -337,6 +402,23 @@ export default function History() {
                         </tbody>
                       </table>
                     </div>
+                    
+                    <div className="chart-grid" style={{ marginTop: 24 }}>
+                      {[
+                        { key: "answer_accuracy", title: "Answer Accuracy (0–10)" },
+                        { key: "context_relevance", title: "Context Relevance (0–10)" },
+                        { key: "time_per_request", title: "Avg Time per Request (s)" },
+                        { key: "token_cost", title: "Total Token Cost" },
+                      ].map(({ key, title }) => (
+                        <div className="chart-card" key={key}>
+                          <Bar
+                            data={makeChart(title, jobDetails.results.map((r) => r.search_type), jobDetails.results.map((r) => r[key]))}
+                            options={chartOpts(title)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+
                   </div>
                 )}
 

--- a/Product/evaluator/Dockerfile
+++ b/Product/evaluator/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pre-cache tiktoken encoding so it works without internet at runtime
+RUN python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+
 COPY . .
 
 EXPOSE 8001

--- a/Product/evaluator/app/evaluation/pipeline.py
+++ b/Product/evaluator/app/evaluation/pipeline.py
@@ -33,13 +33,10 @@ class QuestionGenerator:
         self,
         text: str,
         num_questions: int = 10,
-        chunk_strategy: str = "semantic",
+        chunk_strategy: str = "recursive",
     ) -> List[dict]:
         """Generate QA pairs from raw document text, partitioned into Global and Local questions."""
         import math
-        
-        if chunk_strategy == "summarization":
-            raise NotImplementedError("Summarization chunking strategy is coming soon.")
         
         num_global = num_questions // 2
         num_local = num_questions - num_global
@@ -47,7 +44,45 @@ class QuestionGenerator:
         all_qa_pairs = []
         
         # --- 1. GLOBAL QUESTIONS ---
-        if chunk_strategy == "semantic":
+        if chunk_strategy == "summarization":
+            from langchain_text_splitters import RecursiveCharacterTextSplitter
+            splitter = RecursiveCharacterTextSplitter(chunk_size=15000, chunk_overlap=1500)
+            raw_chunks = splitter.split_text(text)
+            
+            summaries = []
+            for raw in raw_chunks:
+                sys_prompt = "You are an expert summarizer. Summarize the following document chunk, highlighting main themes, relationships, and important narratives. Return only the summary text."
+                try:
+                    if self.provider == "lmstudio":
+                        import httpx
+                        payload = {"model": self.model, "messages": [{"role": "system", "content": sys_prompt}, {"role": "user", "content": raw}], "temperature": 0.0, "max_tokens": 2048}
+                        res = httpx.post(self.base_url, json=payload, timeout=120.0)
+                        res.raise_for_status()
+                        summary = res.json()["choices"][0]["message"]["content"] or ""
+                    else:
+                        resp = self.client.chat.completions.create(model=self.model, messages=[{"role": "system", "content": sys_prompt}, {"role": "user", "content": raw}])
+                        summary = resp.choices[0].message.content or ""
+                    if summary:
+                        summaries.append(summary)
+                except Exception as exc:
+                    logger.error("Failed to summarize chunk: %s", exc)
+            
+            combined_summary = "\n\n".join(summaries)
+            global_chunks = [combined_summary] if combined_summary else [text[:10000]]
+            
+        elif chunk_strategy == "semantic":
+            try:
+                from langchain_huggingface import HuggingFaceEmbeddings
+                from langchain_experimental.text_splitter import SemanticChunker as LCSemanticChunker
+                embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+                global_splitter = LCSemanticChunker(embeddings=embeddings)
+                docs = global_splitter.create_documents([text])
+                global_chunks = [doc.page_content for doc in docs]
+            except ImportError:
+                logger.error("langchain_experimental or langchain_huggingface is missing.")
+                global_chunks = [text[:2000]]
+                
+        elif chunk_strategy == "recursive":
             from langchain_text_splitters import RecursiveCharacterTextSplitter
             global_splitter = RecursiveCharacterTextSplitter(
                 chunk_size=10000,
@@ -55,7 +90,7 @@ class QuestionGenerator:
                 separators=["\n\n", "\n", " ", ""]
             )
             global_chunks = global_splitter.split_text(text)
-        else:
+        else: # "character"
             global_chunk_size = 2000
             global_chunks = [text[i:i+global_chunk_size] for i in range(0, len(text), global_chunk_size)]
         
@@ -136,6 +171,17 @@ Return ONLY a valid JSON object:
 
         # --- 2. LOCAL QUESTIONS ---
         if chunk_strategy == "semantic":
+            try:
+                from langchain_huggingface import HuggingFaceEmbeddings
+                from langchain_experimental.text_splitter import SemanticChunker as LCSemanticChunker
+                embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+                local_splitter = LCSemanticChunker(embeddings=embeddings)
+                docs = local_splitter.create_documents([text])
+                local_chunks = [doc.page_content for doc in docs]
+            except ImportError:
+                local_chunks = [text[:500]]
+                
+        elif chunk_strategy in ("recursive", "summarization"):
             from langchain_text_splitters import RecursiveCharacterTextSplitter
             local_splitter = RecursiveCharacterTextSplitter(
                 chunk_size=2000,
@@ -143,7 +189,7 @@ Return ONLY a valid JSON object:
                 separators=["\n\n", "\n", ".", " ", ""]
             )
             local_chunks = local_splitter.split_text(text)
-        else:
+        else: # "character"
             local_chunk_size = 500
             local_chunks = [text[i:i+local_chunk_size] for i in range(0, len(text), local_chunk_size)]
         

--- a/Product/evaluator/app/evaluation/pipeline.py
+++ b/Product/evaluator/app/evaluation/pipeline.py
@@ -33,9 +33,13 @@ class QuestionGenerator:
         self,
         text: str,
         num_questions: int = 10,
+        chunk_strategy: str = "semantic",
     ) -> List[dict]:
         """Generate QA pairs from raw document text, partitioned into Global and Local questions."""
         import math
+        
+        if chunk_strategy == "summarization":
+            raise NotImplementedError("Summarization chunking strategy is coming soon.")
         
         num_global = num_questions // 2
         num_local = num_questions - num_global
@@ -43,9 +47,17 @@ class QuestionGenerator:
         all_qa_pairs = []
         
         # --- 1. GLOBAL QUESTIONS ---
-        # Global questions need large context to evaluate high-level synthesis and overarching themes.
-        global_chunk_size = 30000
-        global_chunks = [text[i:i+global_chunk_size] for i in range(0, len(text), global_chunk_size)]
+        if chunk_strategy == "semantic":
+            from langchain_text_splitters import RecursiveCharacterTextSplitter
+            global_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=10000,
+                chunk_overlap=1500,
+                separators=["\n\n", "\n", " ", ""]
+            )
+            global_chunks = global_splitter.split_text(text)
+        else:
+            global_chunk_size = 2000
+            global_chunks = [text[i:i+global_chunk_size] for i in range(0, len(text), global_chunk_size)]
         
         if len(global_chunks) > num_global:
             step = max(1, len(global_chunks) // num_global)
@@ -123,9 +135,17 @@ Return ONLY a valid JSON object:
 
 
         # --- 2. LOCAL QUESTIONS ---
-        # Local questions need smaller, focused chunks to ask about specific entities & fast retrieval.
-        local_chunk_size = 4000
-        local_chunks = [text[i:i+local_chunk_size] for i in range(0, len(text), local_chunk_size)]
+        if chunk_strategy == "semantic":
+            from langchain_text_splitters import RecursiveCharacterTextSplitter
+            local_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=2000,
+                chunk_overlap=400,
+                separators=["\n\n", "\n", ".", " ", ""]
+            )
+            local_chunks = local_splitter.split_text(text)
+        else:
+            local_chunk_size = 500
+            local_chunks = [text[i:i+local_chunk_size] for i in range(0, len(text), local_chunk_size)]
         
         if len(local_chunks) > num_local:
             step = max(1, len(local_chunks) // num_local)

--- a/Product/evaluator/app/evaluation/pipeline.py
+++ b/Product/evaluator/app/evaluation/pipeline.py
@@ -29,78 +29,114 @@ class QuestionGenerator:
                 raise ValueError("Missing OPENAI_API_KEY in .env file")
             self.client = OpenAI(api_key=api_key)
 
+    # ── Chunk sizes aligned with GraphRAG ingestion pipeline ──
+    # The RAG pipeline ingests documents at chunk_size=1000, chunk_overlap=200
+    # (see pipeliner/core/config.py → ChunkingConfig).
+    # Local evaluation questions must be generated at the SAME granularity so
+    # the questions are answerable from a single retrieval hit.
+    LOCAL_CHUNK_SIZE = 1000
+    LOCAL_CHUNK_OVERLAP = 200
+
+    # Large window for the Map phase of the summarization pipeline.
+    # Each map-chunk is summarized independently before being reduced.
+    SUMMARY_MAP_CHUNK_SIZE = 15000
+    SUMMARY_MAP_OVERLAP = 1500
+
     def generate_from_text(
         self,
         text: str,
         num_questions: int = 10,
-        chunk_strategy: str = "recursive",
     ) -> List[dict]:
-        """Generate QA pairs from raw document text, partitioned into Global and Local questions."""
-        import math
-        
+        """Generate QA pairs using a dual-strategy pipeline.
+
+        Strategy
+        --------
+        ┌──────────────────────────────────────────────────────────┐
+        │  GLOBAL questions  →  Map-Reduce Summarization          │
+        │                                                          │
+        │  Step 1 (MAP):   Split the full document into large      │
+        │       windows (~15 000 chars, 1 500 overlap).            │
+        │       For each window, ask the LLM to produce a         │
+        │       focused summary that preserves themes,             │
+        │       entity relationships, and narrative arcs.          │
+        │                                                          │
+        │  Step 2 (REDUCE): Concatenate every per-window summary  │
+        │       into a single "super-summary" that covers the     │
+        │       entire document in condensed form.                 │
+        │                                                          │
+        │  Step 3 (GENERATE): Feed that super-summary to the LLM  │
+        │       and request high-level, cross-cutting questions    │
+        │       that require synthesizing multiple sections.       │
+        │       These are the questions best suited for Global     │
+        │       Search evaluation.                                 │
+        ├──────────────────────────────────────────────────────────┤
+        │  LOCAL questions   →  Character Chunking (RAG-aligned)   │
+        │                                                          │
+        │  Split the raw document into 1 000-char chunks with     │
+        │  200-char overlap (matching the GraphRAG ingestion       │
+        │  pipeline's default ChunkingConfig).                     │
+        │                                                          │
+        │  For each selected chunk, ask the LLM to generate       │
+        │  pinpoint factual questions (entity names, numbers,      │
+        │  relationships) that a Local Search retriever should     │
+        │  be able to answer from a single chunk hit.              │
+        └──────────────────────────────────────────────────────────┘
+        """
         num_global = num_questions // 2
         num_local = num_questions - num_global
-        
+
         all_qa_pairs = []
-        
-        # --- 1. GLOBAL QUESTIONS ---
-        if chunk_strategy == "summarization":
-            from langchain_text_splitters import RecursiveCharacterTextSplitter
-            splitter = RecursiveCharacterTextSplitter(chunk_size=15000, chunk_overlap=1500)
-            raw_chunks = splitter.split_text(text)
-            
-            summaries = []
-            for raw in raw_chunks:
-                sys_prompt = "You are an expert summarizer. Summarize the following document chunk, highlighting main themes, relationships, and important narratives. Return only the summary text."
-                try:
-                    if self.provider == "lmstudio":
-                        import httpx
-                        payload = {"model": self.model, "messages": [{"role": "system", "content": sys_prompt}, {"role": "user", "content": raw}], "temperature": 0.0, "max_tokens": 2048}
-                        res = httpx.post(self.base_url, json=payload, timeout=120.0)
-                        res.raise_for_status()
-                        summary = res.json()["choices"][0]["message"]["content"] or ""
-                    else:
-                        resp = self.client.chat.completions.create(model=self.model, messages=[{"role": "system", "content": sys_prompt}, {"role": "user", "content": raw}])
-                        summary = resp.choices[0].message.content or ""
-                    if summary:
-                        summaries.append(summary)
-                except Exception as exc:
-                    logger.error("Failed to summarize chunk: %s", exc)
-            
-            combined_summary = "\n\n".join(summaries)
-            global_chunks = [combined_summary] if combined_summary else [text[:10000]]
-            
-        elif chunk_strategy == "semantic":
+
+        # ================================================================
+        # 1. GLOBAL QUESTIONS — Map-Reduce Summarization
+        # ================================================================
+        # MAP PHASE: split the document into large windows and summarize
+        # each one independently via the LLM.
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+        map_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=self.SUMMARY_MAP_CHUNK_SIZE,
+            chunk_overlap=self.SUMMARY_MAP_OVERLAP,
+        )
+        map_chunks = map_splitter.split_text(text)
+        logger.info(
+            "Summarization MAP phase: %d chunks of ~%d chars",
+            len(map_chunks), self.SUMMARY_MAP_CHUNK_SIZE,
+        )
+
+        summaries: list[str] = []
+        for idx, chunk in enumerate(map_chunks):
+            sys_prompt = "You are an expert summarizer. Summarize the following document chunk, highlighting main themes, relationships, and important narratives. Return only the summary text."
             try:
-                from langchain_huggingface import HuggingFaceEmbeddings
-                from langchain_experimental.text_splitter import SemanticChunker as LCSemanticChunker
-                embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
-                global_splitter = LCSemanticChunker(embeddings=embeddings)
-                docs = global_splitter.create_documents([text])
-                global_chunks = [doc.page_content for doc in docs]
-            except ImportError:
-                logger.error("langchain_experimental or langchain_huggingface is missing.")
-                global_chunks = [text[:2000]]
-                
-        elif chunk_strategy == "recursive":
-            from langchain_text_splitters import RecursiveCharacterTextSplitter
-            global_splitter = RecursiveCharacterTextSplitter(
-                chunk_size=10000,
-                chunk_overlap=1500,
-                separators=["\n\n", "\n", " ", ""]
-            )
-            global_chunks = global_splitter.split_text(text)
-        else: # "character"
-            global_chunk_size = 2000
-            global_chunks = [text[i:i+global_chunk_size] for i in range(0, len(text), global_chunk_size)]
-        
+                summary = self._call_llm(
+                    messages=[
+                        {"role": "system", "content": sys_prompt},
+                        {"role": "user", "content": chunk},
+                    ],
+                )
+                if summary:
+                    summaries.append(summary)
+                    logger.debug("MAP chunk %d/%d summarized (%d chars)", idx + 1, len(map_chunks), len(summary))
+            except Exception as exc:
+                logger.error("MAP chunk %d failed: %s", idx + 1, exc)
+
+        # REDUCE PHASE: merge all per-chunk summaries into one document
+        combined_summary = "\n\n".join(summaries) if summaries else text[:10000]
+        logger.info(
+            "Summarization REDUCE phase complete: combined summary %d chars",
+            len(combined_summary),
+        )
+
+        # GENERATE PHASE: produce global questions from the super-summary
+        global_chunks = [combined_summary]
+
         if len(global_chunks) > num_global:
             step = max(1, len(global_chunks) // num_global)
             global_chunks = global_chunks[::step][:num_global]
-            
+
         q_per_global = max(1, num_global // len(global_chunks)) if global_chunks else 0
         global_rem = num_global % len(global_chunks) if global_chunks else 0
-        
+
         for i, chunk in enumerate(global_chunks):
             q_count = q_per_global + (1 if i < global_rem else 0)
             if q_count <= 0:
@@ -108,17 +144,17 @@ class QuestionGenerator:
 
             prompt = f"""You are an expert evaluation engineer.
 
-=== DOCUMENT CHUNK ===
+=== DOCUMENT SUMMARY ===
 {chunk}
-=== END DOCUMENT CHUNK ===
+=== END DOCUMENT SUMMARY ===
 
-Generate exactly {q_count} GLOBAL question-answer pairs from this chunk.
+Generate exactly {q_count} GLOBAL question-answer pairs from this summary.
 
 CRITICAL RULES FOR GLOBAL QUESTIONS:
-1. Global questions require high-level synthesis. Ask about overarching themes, continuous narratives, or broad aggregated trends across multiple parts of the text.
-2. The questions should NOT be answerable by locating a single specific sentence. They must require synthesizing the entire chunk.
-3. Every question MUST be answerable ONLY from the document chunk above.
-4. Every answer MUST be derived strictly from information in the chunk.
+1. Global questions require high-level synthesis. Ask about overarching themes, continuous narratives, or broad aggregated trends across the document.
+2. The questions should NOT be answerable by locating a single specific sentence. They must require synthesizing multiple sections.
+3. Every question MUST be answerable ONLY from the summary above.
+4. Every answer MUST be derived strictly from information in the summary.
 
 Return ONLY a valid JSON object:
 {{
@@ -126,80 +162,38 @@ Return ONLY a valid JSON object:
 }}"""
 
             try:
-                import re
-                if self.provider == "lmstudio":
-                    import httpx
-                    payload = {
-                        "model": self.model,
-                        "messages": [{"role": "user", "content": prompt}],
-                        "temperature": 0.0,
-                        "max_tokens": 2048
-                    }
-                    res = httpx.post(self.base_url, json=payload, timeout=120.0)
-                    res.raise_for_status()
-                    raw_response = res.json()["choices"][0]["message"]["content"] or ""
-                else:
-                    kwargs = {"response_format": {"type": "json_object"}}
-                    resp = self.client.chat.completions.create(
-                        model=self.model,
-                        messages=[{"role": "user", "content": prompt}],
-                        **kwargs
-                    )
-                    raw_response = resp.choices[0].message.content or ""
-                clean = re.sub(r"<think>.*?</think>", "", raw_response, flags=re.DOTALL).strip()
-                if clean.startswith("```"):
-                   clean = clean.split("\n", 1)[1].rsplit("```", 1)[0]
-                
-                try:
-                    data = json.loads(clean)
-                except json.JSONDecodeError:
-                    match = re.search(r"\{.*\}", clean, flags=re.DOTALL)
-                    if match:
-                        data = json.loads(match.group(0))
-                    else:
-                        raise ValueError("No JSON found")
+                raw_response = self._call_llm(
+                    messages=[{"role": "user", "content": prompt}],
+                    json_mode=True,
+                )
+                data = self._parse_json(raw_response)
 
                 for p in data.get("qa_pairs", []):
                     if p and p.get("question") and p.get("ground_truth_answer") and len(all_qa_pairs) < num_global:
                         all_qa_pairs.append({
-                            "question": f"[Global] {p['question']}", 
+                            "question": f"[Global] {p['question']}",
                             "ground_truth_answer": p["ground_truth_answer"]
                         })
             except Exception as exc:
                 logger.error("Failed to parse GLOBAL QA pairs: %s", exc)
 
+        # ================================================================
+        # 2. LOCAL QUESTIONS — Character Chunking (RAG-aligned)
+        # ================================================================
+        # Use the same chunk_size / overlap as the GraphRAG ingestion
+        # pipeline so the generated questions match retriever granularity.
+        local_chunks = [
+            text[i : i + self.LOCAL_CHUNK_SIZE]
+            for i in range(0, len(text), self.LOCAL_CHUNK_SIZE - self.LOCAL_CHUNK_OVERLAP)
+        ]
 
-        # --- 2. LOCAL QUESTIONS ---
-        if chunk_strategy == "semantic":
-            try:
-                from langchain_huggingface import HuggingFaceEmbeddings
-                from langchain_experimental.text_splitter import SemanticChunker as LCSemanticChunker
-                embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
-                local_splitter = LCSemanticChunker(embeddings=embeddings)
-                docs = local_splitter.create_documents([text])
-                local_chunks = [doc.page_content for doc in docs]
-            except ImportError:
-                local_chunks = [text[:500]]
-                
-        elif chunk_strategy in ("recursive", "summarization"):
-            from langchain_text_splitters import RecursiveCharacterTextSplitter
-            local_splitter = RecursiveCharacterTextSplitter(
-                chunk_size=2000,
-                chunk_overlap=400,
-                separators=["\n\n", "\n", ".", " ", ""]
-            )
-            local_chunks = local_splitter.split_text(text)
-        else: # "character"
-            local_chunk_size = 500
-            local_chunks = [text[i:i+local_chunk_size] for i in range(0, len(text), local_chunk_size)]
-        
         if len(local_chunks) > num_local:
             step = max(1, len(local_chunks) // num_local)
             local_chunks = local_chunks[::step][:num_local]
-            
+
         q_per_local = max(1, num_local // len(local_chunks)) if local_chunks else 0
         local_rem = num_local % len(local_chunks) if local_chunks else 0
-        
+
         for i, chunk in enumerate(local_chunks):
             q_count = q_per_local + (1 if i < local_rem else 0)
             if q_count <= 0:
@@ -225,46 +219,60 @@ Return ONLY a valid JSON object:
 }}"""
 
             try:
-                import re
-                if self.provider == "lmstudio":
-                    import httpx
-                    payload = {
-                        "model": self.model,
-                        "messages": [{"role": "user", "content": prompt}],
-                        "temperature": 0.0,
-                        "max_tokens": 2048
-                    }
-                    res = httpx.post(self.base_url, json=payload, timeout=120.0)
-                    res.raise_for_status()
-                    raw_response = res.json()["choices"][0]["message"]["content"] or ""
-                else:
-                    kwargs = {"response_format": {"type": "json_object"}}
-                    resp = self.client.chat.completions.create(
-                        model=self.model,
-                        messages=[{"role": "user", "content": prompt}],
-                        **kwargs
-                    )
-                    raw_response = resp.choices[0].message.content or ""
-                clean = re.sub(r"<think>.*?</think>", "", raw_response, flags=re.DOTALL).strip()
-                if clean.startswith("```"):
-                   clean = clean.split("\n", 1)[1].rsplit("```", 1)[0]
-                
-                try:
-                    data = json.loads(clean)
-                except json.JSONDecodeError:
-                    match = re.search(r"\{.*\}", clean, flags=re.DOTALL)
-                    if match:
-                        data = json.loads(match.group(0))
-                    else:
-                        raise ValueError("No JSON found")
+                raw_response = self._call_llm(
+                    messages=[{"role": "user", "content": prompt}],
+                    json_mode=True,
+                )
+                data = self._parse_json(raw_response)
 
                 for p in data.get("qa_pairs", []):
                     if p and p.get("question") and p.get("ground_truth_answer") and len(all_qa_pairs) < num_questions:
                         all_qa_pairs.append({
-                            "question": f"[Local] {p['question']}", 
+                            "question": f"[Local] {p['question']}",
                             "ground_truth_answer": p["ground_truth_answer"]
                         })
             except Exception as exc:
                 logger.error("Failed to parse LOCAL QA pairs: %s", exc)
 
         return all_qa_pairs[:num_questions]
+
+    # ── Private helpers ────────────────────────────────────────
+
+    def _call_llm(self, messages: list[dict], json_mode: bool = False) -> str:
+        """Unified LLM call supporting both OpenAI and LMStudio providers."""
+        if self.provider == "lmstudio":
+            import httpx
+            payload = {
+                "model": self.model,
+                "messages": messages,
+                "temperature": 0.0,
+                "max_tokens": 2048,
+            }
+            res = httpx.post(self.base_url, json=payload, timeout=120.0)
+            res.raise_for_status()
+            return res.json()["choices"][0]["message"]["content"] or ""
+        else:
+            kwargs = {}
+            if json_mode:
+                kwargs["response_format"] = {"type": "json_object"}
+            resp = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                **kwargs,
+            )
+            return resp.choices[0].message.content or ""
+
+    @staticmethod
+    def _parse_json(raw: str) -> dict:
+        """Extract a JSON object from an LLM response, handling think-tags and markdown fences."""
+        import re
+        clean = re.sub(r"<think>.*?</think>", "", raw, flags=re.DOTALL).strip()
+        if clean.startswith("```"):
+            clean = clean.split("\n", 1)[1].rsplit("```", 1)[0]
+        try:
+            return json.loads(clean)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", clean, flags=re.DOTALL)
+            if match:
+                return json.loads(match.group(0))
+            raise ValueError("No JSON found in LLM response")

--- a/Product/evaluator/app/evaluation/pipeline.py
+++ b/Product/evaluator/app/evaluation/pipeline.py
@@ -44,7 +44,7 @@ class QuestionGenerator:
         
         # --- 1. GLOBAL QUESTIONS ---
         # Global questions need large context to evaluate high-level synthesis and overarching themes.
-        global_chunk_size = 2000
+        global_chunk_size = 30000
         global_chunks = [text[i:i+global_chunk_size] for i in range(0, len(text), global_chunk_size)]
         
         if len(global_chunks) > num_global:
@@ -124,7 +124,7 @@ Return ONLY a valid JSON object:
 
         # --- 2. LOCAL QUESTIONS ---
         # Local questions need smaller, focused chunks to ask about specific entities & fast retrieval.
-        local_chunk_size = 500
+        local_chunk_size = 4000
         local_chunks = [text[i:i+local_chunk_size] for i in range(0, len(text), local_chunk_size)]
         
         if len(local_chunks) > num_local:

--- a/Product/evaluator/app/routers/evaluation.py
+++ b/Product/evaluator/app/routers/evaluation.py
@@ -139,7 +139,7 @@ async def generate_questions(
     llm_model: str = Form("gpt-4o"),
     doc_id: str = Form(...),
     num_questions: int = Form(10),
-    chunk_strategy: str = Form("semantic"),
+    chunk_strategy: str = Form("recursive"),
     x_chat_id: str = Header(..., alias="X-Chat-Id"),
 ):
     """Generate questions from a document synchronously for review."""

--- a/Product/evaluator/app/routers/evaluation.py
+++ b/Product/evaluator/app/routers/evaluation.py
@@ -139,7 +139,6 @@ async def generate_questions(
     llm_model: str = Form("gpt-4o"),
     doc_id: str = Form(...),
     num_questions: int = Form(10),
-    chunk_strategy: str = Form("recursive"),
     x_chat_id: str = Header(..., alias="X-Chat-Id"),
 ):
     """Generate questions from a document synchronously for review."""
@@ -169,7 +168,7 @@ async def generate_questions(
     from app.evaluation.pipeline import QuestionGenerator
     generator = QuestionGenerator(provider=llm_provider, model=llm_model)
     try:
-        qa_pairs = generator.generate_from_text(text, num_questions=num_questions, chunk_strategy=chunk_strategy)
+        qa_pairs = generator.generate_from_text(text, num_questions=num_questions)
         return {"questions": qa_pairs}
     except Exception as e:
         logger.error("Failed to generate questions: %s", e)

--- a/Product/evaluator/app/routers/evaluation.py
+++ b/Product/evaluator/app/routers/evaluation.py
@@ -139,6 +139,7 @@ async def generate_questions(
     llm_model: str = Form("gpt-4o"),
     doc_id: str = Form(...),
     num_questions: int = Form(10),
+    chunk_strategy: str = Form("semantic"),
     x_chat_id: str = Header(..., alias="X-Chat-Id"),
 ):
     """Generate questions from a document synchronously for review."""
@@ -168,7 +169,7 @@ async def generate_questions(
     from app.evaluation.pipeline import QuestionGenerator
     generator = QuestionGenerator(provider=llm_provider, model=llm_model)
     try:
-        qa_pairs = generator.generate_from_text(text, num_questions=num_questions)
+        qa_pairs = generator.generate_from_text(text, num_questions=num_questions, chunk_strategy=chunk_strategy)
         return {"questions": qa_pairs}
     except Exception as e:
         logger.error("Failed to generate questions: %s", e)

--- a/Product/evaluator/app/routers/evaluation.py
+++ b/Product/evaluator/app/routers/evaluation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
 from typing import List, Optional
 
@@ -38,6 +39,7 @@ async def start_evaluation(
     llm_provider: str = Form("lmstudio"),
     llm_model: str = Form("gpt-4o"),
     doc_id: Optional[str] = Form(None),
+    qa_pairs: Optional[str] = Form(None),
     x_chat_id: str = Header(..., alias="X-Chat-Id"),
     file: Optional[UploadFile] = File(None),
 ):
@@ -60,18 +62,25 @@ async def start_evaluation(
             detail=f"Invalid search types: {invalid}. Choose from: {valid}",
         )
 
-    if question_source not in ("custom", "auto"):
-        raise HTTPException(status_code=400, detail="question_source must be 'custom' or 'auto'.")
+    if question_source not in ("custom", "auto", "manual"):
+        raise HTTPException(status_code=400, detail="question_source must be 'custom', 'auto', or 'manual'.")
 
     uploaded_csv_bytes: Optional[bytes] = None
     document_texts: Optional[List[str]] = None
+    parsed_qa_pairs: Optional[List[dict]] = None
+
+    if qa_pairs:
+        try:
+            parsed_qa_pairs = json.loads(qa_pairs)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="qa_pairs must be valid JSON")
 
     if question_source == "custom":
         if not file:
             raise HTTPException(status_code=400, detail="CSV file is required when question_source='custom'.")
         uploaded_csv_bytes = await file.read()
 
-    elif question_source == "auto":
+    elif question_source == "auto" and not parsed_qa_pairs:
         with connection() as conn:
             with conn.cursor() as cur:
                 if doc_id:
@@ -116,11 +125,54 @@ async def start_evaluation(
         question_source=question_source,
         uploaded_csv_bytes=uploaded_csv_bytes,
         document_texts=document_texts,
+        provided_qa_pairs=parsed_qa_pairs,
         llm_provider=llm_provider,
         llm_model=llm_model,
     )
 
     return {"job_id": job_id, "status": "pending"}
+
+
+@router.post("/generate-questions")
+async def generate_questions(
+    llm_provider: str = Form("lmstudio"),
+    llm_model: str = Form("gpt-4o"),
+    doc_id: str = Form(...),
+    num_questions: int = Form(10),
+    x_chat_id: str = Header(..., alias="X-Chat-Id"),
+):
+    """Generate questions from a document synchronously for review."""
+    if num_questions < 1 or num_questions > 20:
+        raise HTTPException(status_code=400, detail="num_questions must be between 1 and 20.")
+
+    with connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT path, content_type FROM documents WHERE id = %s AND chat_id = %s",
+                (doc_id, x_chat_id),
+            )
+            doc = cur.fetchone()
+
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found.")
+
+    try:
+        file_bytes = read_document_bytes(dict(doc)["path"])
+        text = _extract_text(file_bytes, dict(doc).get("content_type", ""))
+        if not text.strip():
+            raise ValueError("Document text is empty.")
+    except Exception as e:
+        logger.warning("Failed to extract text: %s", e)
+        raise HTTPException(status_code=500, detail="Could not extract text from document.")
+
+    from app.evaluation.pipeline import QuestionGenerator
+    generator = QuestionGenerator(provider=llm_provider, model=llm_model)
+    try:
+        qa_pairs = generator.generate_from_text(text, num_questions=num_questions)
+        return {"questions": qa_pairs}
+    except Exception as e:
+        logger.error("Failed to generate questions: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/status/{job_id}", response_model=EvaluationJobStatus)

--- a/Product/evaluator/app/services/evaluation_service.py
+++ b/Product/evaluator/app/services/evaluation_service.py
@@ -107,6 +107,7 @@ def start_evaluation_job(
     question_source: str,
     uploaded_csv_bytes: Optional[bytes] = None,
     document_texts: Optional[List[str]] = None,
+    provided_qa_pairs: Optional[List[dict]] = None,
     llm_provider: str = "openai",
     llm_model: str = "gpt-4o",
 ) -> None:
@@ -114,7 +115,17 @@ def start_evaluation_job(
     try:
         qa_rows: List[Dict[str, str]] = []
 
-        if question_source == "custom" and uploaded_csv_bytes:
+        if provided_qa_pairs:
+            _update_job(job_id, status="generating_questions", progress="Using manually reviewed questions...")
+            for pair in provided_qa_pairs:
+                q = pair.get("question", "").strip()
+                a = pair.get("ground_truth_answer", "").strip()
+                if q and a:
+                    qa_rows.append({"question": q, "ground_truth_answer": a})
+            if not qa_rows:
+                raise ValueError("Provided QA pairs were empty or invalid.")
+
+        elif question_source == "custom" and uploaded_csv_bytes:
             _update_job(job_id, status="generating_questions", progress="Parsing uploaded CSV...")
             qa_rows = _parse_csv(uploaded_csv_bytes)
             if not qa_rows:

--- a/Product/evaluator/requirements.txt
+++ b/Product/evaluator/requirements.txt
@@ -16,6 +16,8 @@ graphdatascience==1.19
 # Text processing
 sentence-transformers==3.4.1
 langchain-text-splitters==1.1.0
+langchain-huggingface==1.2.0
+langchain-experimental==0.4.1
 tiktoken==0.11.0
 nltk==3.9.2
 


### PR DESCRIPTION
###  **1. The naivety of our global questions were mostly due to chunks' size.  I also added different chunking strategies while keeping character option's chunk size as before:**

- Recursive: Smart character boundaries focusing on paragraph blocks (\n\n).

- Semantic: Deploys the locally hosted all-MiniLM-L6-v2 embedding model to mathematically detect "topic shifts" and splits chunks dynamically based on conversational deviations!

- Summarization: Triggers a high-level map-reduce execution loop where the LLM chunks and summarizes the entire document before synthesizing overarching "Global" questions.

- Character: Raw string truncation logic


**2. Added an option to choose and edit previously used datasets. Also the newly generated qa pairs are being shown as editable then needs confirmation before the pipeline. The datasets are rendered with the name of document and time it has been created. Also the number of question can be selected between min being 1 and max 20.** 


**3. History page shows the document names, date and report graphs for each evaluation.** 
