### PR TITLE
added ollama management part to UI, we can downloand the models from …

### DIFF
--- a/Product/dashboard/src/api.js
+++ b/Product/dashboard/src/api.js
@@ -249,3 +249,46 @@ export async function getEvaluationJobDetails(jobId) {
   if (!res.ok) return null;
   return res.json();
 }
+
+// ── Ollama Models ───────────────────────────────────────
+
+export async function getOllamaRecommendations() {
+  const res = await fetch(`${PIPELINER_BASE}/api/ollama/recommendations`);
+  if (!res.ok) throw new Error((await res.json()).detail || res.statusText);
+  return res.json();
+}
+
+export async function pullOllamaModel(model, onProgress) {
+  const res = await fetch(`${PIPELINER_BASE}/api/ollama/pull`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model }),
+  });
+  
+  if (!res.ok) throw new Error((await res.json()).detail || res.statusText);
+  
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        if (event.error) throw new Error(event.error);
+        if (onProgress) onProgress(event);
+      } catch (e) {
+        if (e.message && e.message !== "Unexpected end of JSON input") throw e;
+      }
+    }
+  }
+}
+

--- a/Product/dashboard/src/pages/Pipeline.jsx
+++ b/Product/dashboard/src/pages/Pipeline.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { connectPipeline, getDocuments, getPipelineConfig } from "../api";
+import { connectPipeline, getDocuments, getPipelineConfig, getOllamaRecommendations, pullOllamaModel } from "../api";
 
 // Fallbacks used until the API response arrives
 const DEFAULT_PROVIDERS = ["openai", "lmstudio", "ollama"];
@@ -80,6 +80,47 @@ export default function Pipeline() {
   const [llmProviders, setLlmProviders] = useState(DEFAULT_MODELS);
   const [embeddingModels, setEmbeddingModels] = useState(DEFAULT_EMBEDDING_MODELS);
   const [chunkers, setChunkers] = useState(DEFAULT_CHUNKERS);
+
+  // Ollama Model Manager State
+  const [showOllamaModal, setShowOllamaModal] = useState(false);
+  const [ollamaRecs, setOllamaRecs] = useState(null);
+  const [pullingModel, setPullingModel] = useState(null);
+  const [pullProgress, setPullProgress] = useState("");
+  const [userRam, setUserRam] = useState(16); // Default selection
+
+  useEffect(() => {
+    if (showOllamaModal && !ollamaRecs) {
+      getOllamaRecommendations().then(setOllamaRecs).catch(console.error);
+    }
+  }, [showOllamaModal, ollamaRecs]);
+
+  async function handlePullModel(modelName) {
+    if (pullingModel) return;
+    setPullingModel(modelName);
+    setPullProgress("Starting download...");
+    try {
+      await pullOllamaModel(modelName, (event) => {
+         if (event.status) {
+           let p = event.status;
+           if (event.total && event.completed) {
+              const pct = Math.round((event.completed / event.total) * 100);
+              p += ` (${pct}%)`;
+           }
+           setPullProgress(p);
+         }
+      });
+      setPullProgress("Download complete!");
+      // Refresh models list in dropdown
+      const cfg = await getPipelineConfig();
+      if (cfg.llm_providers) setLlmProviders(cfg.llm_providers);
+      setTimeout(() => {
+         setPullingModel(null);
+      }, 1500);
+    } catch(e) {
+      setPullProgress("Error: " + e.message);
+      setTimeout(() => setPullingModel(null), 3000);
+    }
+  }
 
   useEffect(() => {
     getDocuments().then((d) => {
@@ -228,7 +269,19 @@ export default function Pipeline() {
 
         <div className="form-row">
           <div className="form-group">
-            <label>Model</label>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "4px" }}>
+              <label style={{ marginBottom: 0 }}>Model</label>
+              {provider === "ollama" && (
+                <button 
+                  className="btn btn-outline" 
+                  style={{ padding: "2px 8px", fontSize: "11px" }}
+                  onClick={() => setShowOllamaModal(true)}
+                  disabled={running}
+                >
+                  📥 Manage Models
+                </button>
+              )}
+            </div>
             <select value={model} onChange={(e) => setModel(e.target.value)}>
               {(MODELS[provider] || []).map((m) => (
                 <option key={m}>{m}</option>
@@ -452,6 +505,92 @@ export default function Pipeline() {
               </div>
             )}
             <div ref={logEndRef} />
+          </div>
+        </div>
+      )}
+
+      {/* Ollama Model Manager Modal */}
+      {showOllamaModal && (
+        <div className="modal-overlay" style={{
+          position: "fixed", top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: "rgba(0,0,0,0.5)", zIndex: 1000,
+          display: "flex", alignItems: "center", justifyContent: "center"
+        }}>
+          <div className="modal-content card" style={{ width: 600, maxWidth: "90%", maxHeight: "90vh", overflowY: "auto", padding: 24 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 20 }}>
+              <div>
+                <h3 style={{ margin: "0 0 8px 0" }}>📥 Ollama Model Manager</h3>
+                <div style={{ fontSize: 13, color: "var(--text-dim)", display: "flex", alignItems: "center", gap: 8 }}>
+                  <span>My Mac's Unified Memory:</span>
+                  <select 
+                    value={userRam} 
+                    onChange={(e) => setUserRam(Number(e.target.value))}
+                    style={{ padding: "2px 8px", fontSize: 12, borderRadius: 4 }}
+                  >
+                    <option value={8}>8 GB</option>
+                    <option value={16}>16 GB</option>
+                    <option value={32}>32 GB+</option>
+                  </select>
+                </div>
+              </div>
+              <button className="btn btn-outline" onClick={() => setShowOllamaModal(false)} disabled={!!pullingModel}>✕</button>
+            </div>
+
+            {ollamaRecs && ollamaRecs.tiers.map((tier) => {
+              const isRecommended = userRam >= tier.min_ram_gb && userRam < tier.max_ram_gb;
+              return (
+              <div key={tier.id} style={{
+                marginBottom: 16,
+                padding: 16,
+                borderRadius: 8,
+                border: isRecommended ? "2px solid var(--accent)" : "1px solid var(--border)",
+                backgroundColor: isRecommended ? "rgba(99, 102, 241, 0.05)" : "transparent"
+              }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+                  <h4 style={{ margin: 0 }}>{tier.name}</h4>
+                  {isRecommended && <span style={{ fontSize: 11, fontWeight: "bold", color: "var(--accent)", backgroundColor: "rgba(99, 102, 241, 0.1)", padding: "2px 8px", borderRadius: 12 }}>⭐ Recommended for {userRam}GB</span>}
+                </div>
+                <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 12 }}>{tier.description}</div>
+                
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  {tier.models.map((m) => {
+                    const baseName = m.name.split(":")[0];
+                    const isDownloaded = MODELS["ollama"]?.some(installed => installed.split(":")[0] === baseName);
+                    const isPulling = pullingModel === m.name;
+                    return (
+                      <div key={m.name} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 12px", backgroundColor: "var(--bg-subtle)", borderRadius: 6 }}>
+                        <div>
+                          <div style={{ fontWeight: 500, fontSize: 14 }}>{m.name} <span style={{ fontSize: 11, color: "var(--text-dim)", marginLeft: 8 }}>{m.size}</span></div>
+                          <div style={{ fontSize: 12, color: "var(--text-dim)" }}>{m.desc}</div>
+                        </div>
+                        <div style={{ textAlign: "right", minWidth: 120 }}>
+                          {isDownloaded ? (
+                            <span style={{ fontSize: 12, color: "var(--green)", fontWeight: 500 }}>✔ Downloaded</span>
+                          ) : isPulling ? (
+                            <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
+                              <span style={{ fontSize: 12, fontWeight: 500, color: "var(--accent)" }}>Downloading...</span>
+                              <span style={{ fontSize: 11, color: "var(--text-dim)", fontFamily: "monospace", whiteSpace: "nowrap" }}>{pullProgress}</span>
+                            </div>
+                          ) : (
+                            <button 
+                              className="btn btn-primary" 
+                              style={{ padding: "4px 12px", fontSize: 12 }}
+                              disabled={!!pullingModel}
+                              onClick={() => handlePullModel(m.name)}
+                            >
+                              ⬇ Download
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+              );
+            })}
+
+
           </div>
         </div>
       )}

--- a/Product/pipeliner/api/pipeline_routes.py
+++ b/Product/pipeliner/api/pipeline_routes.py
@@ -6,6 +6,7 @@ import logging
 import traceback
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 from core.config import (
     PipelineConfig,
@@ -184,3 +185,73 @@ async def run_pipeline(ws: WebSocket):
             await ws.close()
         except Exception:
             pass
+
+class PullRequest(BaseModel):
+    model: str
+
+@router.get("/api/ollama/recommendations")
+async def get_ollama_recommendations():
+    tiers = [
+        {
+            "id": "tier1",
+            "name": "Tier 1: Lightweight",
+            "description": "Best for <8GB RAM or older machines. Fast but lower reasoning.",
+            "min_ram_gb": 0,
+            "max_ram_gb": 12,
+            "models": [
+                {"name": "phi3:mini", "size": "3.8B", "desc": "Good at following strict instructions."},
+                {"name": "llama3.2:3b", "size": "3B", "desc": "Lightweight Llama model, surprisingly smart."},
+                {"name": "gemma2:2b", "size": "2B", "desc": "Google's small powerhouse for basic tasks."},
+                {"name": "qwen2.5:1.5b", "size": "1.5B", "desc": "Extremely fast, good for low-end hardware."}
+            ]
+        },
+        {
+            "id": "tier2",
+            "name": "Tier 2: Balanced",
+            "description": "Best for 16GB RAM. The gold standard for local GraphRAG.",
+            "min_ram_gb": 12,
+            "max_ram_gb": 24,
+            "models": [
+                {"name": "llama3.1:latest", "size": "8B", "desc": "Excellent local extraction and reasoning."},
+                {"name": "llama3:latest", "size": "8B", "desc": "Classic Llama 3 8B model."},
+                {"name": "qwen2.5:7b", "size": "7B", "desc": "Incredible reasoning and coding capabilities."},
+                {"name": "mistral-nemo:latest", "size": "12B", "desc": "Massive 128k context window, great for graphs."},
+                {"name": "gemma2:9b", "size": "9B", "desc": "Punches above its weight class in logic."},
+                {"name": "mistral:latest", "size": "7B", "desc": "Solid alternative to Llama 3."}
+            ]
+        },
+        {
+            "id": "tier3",
+            "name": "Tier 3: Heavyweight",
+            "description": "Best for 32GB+ RAM. Ultimate local quality.",
+            "min_ram_gb": 24,
+            "max_ram_gb": 999,
+            "models": [
+                {"name": "qwen2.5:32b", "size": "32B", "desc": "Near GPT-4 performance for local GraphRAG."},
+                {"name": "command-r:latest", "size": "35B", "desc": "Optimized specifically for RAG workflows."},
+                {"name": "mixtral:8x7b", "size": "47B", "desc": "Fast Mixture of Experts model."},
+                {"name": "llama3.1:70b", "size": "70B", "desc": "Requires heavy hardware but unmatched quality."}
+            ]
+        }
+    ]
+            
+    return {"tiers": tiers}
+
+@router.post("/api/ollama/pull")
+async def pull_ollama_model(req: PullRequest):
+    import httpx
+    from fastapi.responses import StreamingResponse
+    
+    base_url = OLLAMA_BASE_URL.split("/v1")[0].rstrip("/")
+    
+    async def stream_pull():
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                async with client.stream("POST", f"{base_url}/api/pull", json={"name": req.model}) as r:
+                    async for chunk in r.aiter_bytes():
+                        yield chunk
+        except Exception as e:
+            yield f'{{"error":"{str(e)}"}}\n'.encode("utf-8")
+                    
+    return StreamingResponse(stream_pull(), media_type="application/x-ndjson")
+


### PR DESCRIPTION
These are the details.

- User still need to open ollama from their local. (It is just pressing ollama desktop symbol in mac ).
- In the pipeline UI, when you select ollama you will see button at the models part, it will see the recommended models for different RAMs (models are hardcoded, but it will give it is already downloanded or not as button in the pop up with ollama endpoint). Ollama has not endpoint like all available "pullable" models, but it is also sufficient to put GraphRag suitable available models to UI. 
-- So basically user needs to just open ollama , than nothing to do other than using dashboard. 



Ollama usage :

- I run llama:latest, llama:3.2:3b, phi3:mini, when I run with concurrency 5, one request is like 60 seconds .

But when I run it with concurrency: 1, one request takes 6-10 seconds in my mac (more reasonable time ).

I did not run the pipeline end to end , I will do it .
Since default max token is 16284 in our code, it does not create problem for ollama .

But this is the current situation, you can look at the UI and merge the PR.